### PR TITLE
fix error message when LaTex compilation fails

### DIFF
--- a/src/dgcv/core/validation.py
+++ b/src/dgcv/core/validation.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from dgcv.configuration.cfg import config
 from dgcv.core.execution_parameters import Parameters
 from dgcv.core.global_variables import (
+    CASE_SEPARATOR,
     ELECTRIC_PERFORMANCE_BESS,
     ELECTRIC_PERFORMANCE_PPM,
     ELECTRIC_PERFORMANCE_SM,
@@ -31,6 +32,13 @@ from dgcv.logging.logging import dgcv_logging
 from dgcv.model.pcs import Pcs
 from dgcv.report import report
 from dgcv.report.LatexReportException import LatexReportException
+
+
+def _aborted_execution(e: Exception) -> None:
+    if dgcv_logging.getEffectiveLevel() == logging.DEBUG:
+        dgcv_logging.get_logger("Validation").exception(f"Aborted execution. {e}")
+    else:
+        dgcv_logging.get_logger("Validation").error(f"Aborted execution. {e}")
 
 
 def _open_document(file: Path, is_testing: bool) -> None:
@@ -167,12 +175,15 @@ class Validation:
                 self._parameters,
                 Path(self._path_latex_files),
             )
-        except (LatexReportException, FileNotFoundError, IOError, ValueError) as e:
-            if dgcv_logging.getEffectiveLevel() == logging.DEBUG:
-                dgcv_logging.get_logger("Validation").exception(f"Aborted execution. {e}")
-            else:
-                dgcv_logging.get_logger("Validation").error(f"Aborted execution. {e}")
-            sys.exit(1)
+        except LatexReportException as e:
+            dgcv_logging.get_logger("PDFLatex").error(
+                f"An error occurred while generating the report, "
+                f"look for the {REPORT_NAME.split(CASE_SEPARATOR)[0]}.log file "
+                f"under {self._parameters.get_output_dir()/'Reports'}"
+            )
+            _aborted_execution(e)
+        except (FileNotFoundError, IOError, ValueError) as e:
+            _aborted_execution(e)
 
         for pcs_results in report_results.values():
             pcs = pcs_results["pcs"]
@@ -242,12 +253,6 @@ class Validation:
         # Create the pcs report
         if not is_test_validation:
             self.__create_report(summary_list, report_results)
-
-            manage_files.copy_output_files(
-                "Reports",
-                self._parameters.get_working_dir(),
-                self._parameters.get_output_dir(),
-            )
 
             report_file = (
                 self._parameters.get_output_dir() / "Reports" / REPORT_NAME.replace("tex", "pdf")

--- a/src/dgcv/report/report.py
+++ b/src/dgcv/report/report.py
@@ -32,7 +32,8 @@ from dgcv.files.manage_files import copy_latex_files, move_report
 from dgcv.logging.logging import dgcv_logging
 from dgcv.model.compliance import Compliance
 from dgcv.model.producer import Producer
-from dgcv.report import LatexReportException, figure, html
+from dgcv.report import figure, html
+from dgcv.report.LatexReportException import LatexReportException
 from dgcv.report.tables import (
     active_power_recovery,
     characteristics_response,
@@ -504,8 +505,4 @@ def create_pdf(
     if move_report(working_path, output_path, REPORT_NAME):
         dgcv_logging.get_logger("PDFLatex").info("PDF done.")
     else:
-        dgcv_logging.get_logger("PDFLatex").error(
-            f"An error occurred while generating the report, "
-            f"log in {REPORT_NAME.split(CASE_SEPARATOR)[0]}.log"
-        )
         raise LatexReportException("PDFLatex Error.")


### PR DESCRIPTION
The error message is modified to indicate to the user where the generated log file is located.

All files created by the tool are copied to the results directory even if the report generation fails.