### PR TITLE
add voltage droop parameter for IECWPP4B2020

### DIFF
--- a/src/dgcv/dynawo/dictionary/Power_Park.ini
+++ b/src/dgcv/dynawo/dictionary/Power_Park.ini
@@ -191,6 +191,7 @@ MagnitudeControlledByAVRQPu = WPP_wPPControl_measurements_QPu
 NetworkFrequencyPu = WPP_omegaRefPu
 NetworkFrequencyValue = WPP_omegaRefPu
 InjectedCurrentMax = WPP_IMaxPu
+VoltageDrop = WPP_Kwpqu
 
 [WT4AWeccCurrentSource]
 ActivePower0Pu = WT4A_P0Pu


### PR DESCRIPTION
voltage droop parameter was missing in PowerPark.ini for IEC WPP4B 2020 model