### PR TITLE
Fix figures description

### DIFF
--- a/src/dycov/templates/reports/model/BESS/.DummySample/commonDummy.tex
+++ b/src/dycov/templates/reports/model/BESS/.DummySample/commonDummy.tex
@@ -88,7 +88,7 @@
         \centering
         \includegraphics[width=\textwidth]{fig_Ire_PCS_Iz1.\DTRPcs.\OCname}
         \begin{minipage}[t]{0.8\textwidth}
-            \small Active current output Ire, measured at the PDR bus.
+            \small Active current output Ip,measured at the PDR bus.
         \end{minipage}
     \end{minipage}
 %
@@ -97,7 +97,7 @@
         \centering
         \includegraphics[width=\textwidth]{fig_Iim_PCS_Iz1.\DTRPcs.\OCname}
         \begin{minipage}[t]{0.8\textwidth}
-            \small Reactive current output Iim, measured at the PDR bus.
+            \small Reactive current output Iq,measured at the PDR bus.
         \end{minipage}
     \end{minipage}
 }

--- a/src/dycov/templates/reports/model/BESS/PCS_RTE-I16z1/commonz1.tex
+++ b/src/dycov/templates/reports/model/BESS/PCS_RTE-I16z1/commonz1.tex
@@ -88,7 +88,7 @@
         \centering
         \includegraphics[width=\textwidth]{fig_Ire_PCS_RTE-I16z1.\DTRPcs.\OCname}
         \begin{minipage}[t]{0.8\textwidth}
-            \small Active current output Ire, measured at the PDR bus.
+            \small Active current output Ip,measured at the PDR bus.
         \end{minipage}
     \end{minipage}
     \hfill
@@ -96,7 +96,7 @@
         \centering
         \includegraphics[width=\textwidth]{fig_Iim_PCS_RTE-I16z1.\DTRPcs.\OCname}
         \begin{minipage}[t]{0.8\textwidth}
-            \small Reactive current output Iim, measured at the PDR bus.
+            \small Reactive current output Iq,measured at the PDR bus.
         \end{minipage}
     \end{minipage}
 }

--- a/src/dycov/templates/reports/model/BESS/PCS_RTE-I16z3/commonz3.tex
+++ b/src/dycov/templates/reports/model/BESS/PCS_RTE-I16z3/commonz3.tex
@@ -88,7 +88,7 @@
         \centering
         \includegraphics[width=\textwidth]{fig_Ire_PCS_RTE-I16z3.\DTRPcs.\OCname}
         \begin{minipage}[t]{0.8\textwidth}
-            \small Active current output Ire, measured at the PDR bus.
+            \small Active current output Ip,measured at the PDR bus.
         \end{minipage}
     \end{minipage}
     \hfill
@@ -96,7 +96,7 @@
         \centering
         \includegraphics[width=\textwidth]{fig_Iim_PCS_RTE-I16z3.\DTRPcs.\OCname}
         \begin{minipage}[t]{0.8\textwidth}
-            \small Reactive current output Iim, measured at the PDR bus.
+            \small Reactive current output Iq,measured at the PDR bus.
         \end{minipage}
     \end{minipage}
 }

--- a/src/dycov/templates/reports/model/BESS/PCS_RTE-I16z3/report.ThreePhaseFault.TransientBolted.tex
+++ b/src/dycov/templates/reports/model/BESS/PCS_RTE-I16z3/report.ThreePhaseFault.TransientBolted.tex
@@ -122,7 +122,7 @@
         \centering
         \includegraphics[width=\textwidth]{fig_Ire_PCS_RTE-I16z3.\DTRPcs.\OCname}
         \begin{minipage}[t]{0.8\textwidth}
-            \small Active current output Ire, measured at the PDR bus.
+            \small Active current output Ip,measured at the PDR bus.
         \end{minipage}
     \end{minipage}
     \hfill
@@ -130,7 +130,7 @@
         \centering
         \includegraphics[width=\textwidth]{fig_Iim_PCS_RTE-I16z3.\DTRPcs.\OCname}
         \begin{minipage}[t]{0.8\textwidth}
-            \small Reactive current output Iim, measured at the PDR bus.
+            \small Reactive current output Iq,measured at the PDR bus.
         \end{minipage}
     \end{minipage}
 

--- a/src/dycov/templates/reports/model/PPM/.DummySample/commonDummy.tex
+++ b/src/dycov/templates/reports/model/PPM/.DummySample/commonDummy.tex
@@ -88,7 +88,7 @@
         \centering
         \includegraphics[width=\textwidth]{fig_Ire_PCS_Iz1.\DTRPcs.\OCname}
         \begin{minipage}[t]{0.8\textwidth}
-            \small Active current output Ire, measured at the PDR bus.
+            \small Active current output Ip,measured at the PDR bus.
         \end{minipage}
     \end{minipage}
 %
@@ -97,7 +97,7 @@
         \centering
         \includegraphics[width=\textwidth]{fig_Iim_PCS_Iz1.\DTRPcs.\OCname}
         \begin{minipage}[t]{0.8\textwidth}
-            \small Reactive current output Iim, measured at the PDR bus.
+            \small Reactive current output Iq,measured at the PDR bus.
         \end{minipage}
     \end{minipage}
 }

--- a/src/dycov/templates/reports/model/PPM/PCS_RTE-I16z1/commonz1.tex
+++ b/src/dycov/templates/reports/model/PPM/PCS_RTE-I16z1/commonz1.tex
@@ -88,7 +88,7 @@
         \centering
         \includegraphics[width=\textwidth]{fig_Ire_PCS_RTE-I16z1.\DTRPcs.\OCname}
         \begin{minipage}[t]{0.8\textwidth}
-            \small Active current output Ire, measured at the PDR bus.
+            \small Active current output Ip,measured at the PDR bus.
         \end{minipage}
     \end{minipage}
     \hfill
@@ -96,7 +96,7 @@
         \centering
         \includegraphics[width=\textwidth]{fig_Iim_PCS_RTE-I16z1.\DTRPcs.\OCname}
         \begin{minipage}[t]{0.8\textwidth}
-            \small Reactive current output Iim, measured at the PDR bus.
+            \small Reactive current output Iq,measured at the PDR bus.
         \end{minipage}
     \end{minipage}
 }

--- a/src/dycov/templates/reports/model/PPM/PCS_RTE-I16z3/commonz3.tex
+++ b/src/dycov/templates/reports/model/PPM/PCS_RTE-I16z3/commonz3.tex
@@ -100,7 +100,7 @@
         \centering
         \includegraphics[width=\textwidth]{fig_Ire_PCS_RTE-I16z3.\DTRPcs.\OCname}
         \begin{minipage}[t]{0.8\textwidth}
-            \small Active current output Ire, measured at the PDR bus.
+            \small Active current output Ip,measured at the PDR bus.
         \end{minipage}
     \end{minipage}
     \hfill
@@ -108,7 +108,7 @@
         \centering
         \includegraphics[width=\textwidth]{fig_Iim_PCS_RTE-I16z3.\DTRPcs.\OCname}
         \begin{minipage}[t]{0.8\textwidth}
-            \small Reactive current output Iim, measured at the PDR bus.
+            \small Reactive current output Iq,measured at the PDR bus.
         \end{minipage}
     \end{minipage}
 }

--- a/src/dycov/templates/reports/model/PPM/PCS_RTE-I16z3/report.ThreePhaseFault.TransientBolted.tex
+++ b/src/dycov/templates/reports/model/PPM/PCS_RTE-I16z3/report.ThreePhaseFault.TransientBolted.tex
@@ -122,7 +122,7 @@
         \centering
         \includegraphics[width=\textwidth]{fig_Ire_PCS_RTE-I16z3.\DTRPcs.\OCname}
         \begin{minipage}[t]{0.8\textwidth}
-            \small Active current output Ire, measured at the PDR bus.
+            \small Active current output Ip,measured at the PDR bus.
         \end{minipage}
     \end{minipage}
     \hfill
@@ -130,7 +130,7 @@
         \centering
         \includegraphics[width=\textwidth]{fig_Iim_PCS_RTE-I16z3.\DTRPcs.\OCname}
         \begin{minipage}[t]{0.8\textwidth}
-            \small Reactive current output Iim, measured at the PDR bus.
+            \small Reactive current output Iq,measured at the PDR bus.
         \end{minipage}
     \end{minipage}
 

--- a/src/dycov/templates/reports/report.tex
+++ b/src/dycov/templates/reports/report.tex
@@ -94,10 +94,10 @@
     \begin{center}
         \begin{tabular}{ccccc}
             \toprule
-            Producer & Pcs & Benchmark & Operating Condition & Overall Result \\
+            Pcs & Benchmark & Operating Condition & Overall Result \\
             \midrule
             \BLOCK{for row in summaryReport}
-            {{row[0]}} & {{row[1]}} & {{row[2]}} & {{row[3]}} & {{row[4]}} \\
+            {{row[0]}} & {{row[1]}} & {{row[2]}} & {{row[3]}} \\
             \BLOCK{endfor}
             \bottomrule
         \end{tabular}


### PR DESCRIPTION
Rename active/reactive current in the figures description