### PR TITLE
Exceeded the maximum execution time allowed

### DIFF
--- a/src/dycov/dynawo/dynawo.py
+++ b/src/dycov/dynawo/dynawo.py
@@ -19,6 +19,7 @@ import numpy as np
 import pandas as pd
 from lxml import etree
 
+from dycov.files import manage_files
 from dycov.logging.logging import dycov_logging
 from dycov.validation.common import is_stable
 
@@ -200,7 +201,7 @@ def _run_dynawo(
             )
         else:
             os.killpg(
-                os.getpgid(proc.pid), signal.SIGTERM
+                os.getpgid(proc.pid), signal.SIGKILL
             )  # Send the signal to all the process groups
     else:
         stderr = proc.stderr.read().decode("utf-8")
@@ -642,10 +643,13 @@ def run_base_dynawo(
     float
         Time taken for the simulation
     """
+    # Remove previous output directory (Dynawo does not remove old output directories)
+    dynawo_output_dir = inputs_path / output_path
+    manage_files.remove_dir(dynawo_output_dir)
+
     success, stderr, sim_time = _run_dynawo(
         launcher_dwo, jobs_filename, inputs_path, simulation_limit
     )
-    dynawo_output_dir = inputs_path / output_path
 
     log = None
     has_error = False


### PR DESCRIPTION
Refactor Dynawo output handling: use SIGKILL for process termination and ensure previous output directory is removed before simulation