### PR TITLE
Fix KPI thresholds displayed in the report

### DIFF
--- a/src/dycov/curves/importer/curves.py
+++ b/src/dycov/curves/importer/curves.py
@@ -94,9 +94,11 @@ class ImportedCurves(ProducerCurves):
             )
 
             if importer.config.has_option("Curves-Metadata", "is_field_measurements"):
-                self._is_field_measurements = bool(
-                    importer.config.get("Curves-Metadata", "is_field_measurements")
+                self._is_field_measurements = (
+                    importer.config.get("Curves-Metadata", "is_field_measurements").lower()
+                    == "true"
                 )
+            self.get_producer().set_is_field_measurements(self._is_field_measurements)
 
             generators_imax = {}
             for key in importer.config["Curves-Metadata"].keys():

--- a/src/dycov/model/producer.py
+++ b/src/dycov/model/producer.py
@@ -72,6 +72,7 @@ class Producer:
         self._is_dynawo_model = self._producer_model_path is not None
         self._is_user_curves = self._producer_curves_path is not None
         self._has_reference_curves_path = self._reference_curves_path is not None
+        self._is_field_measurements = False
 
         if verification_type == ELECTRIC_PERFORMANCE:
             self.__set_electric_performance_type()
@@ -543,3 +544,22 @@ class Producer:
             Equipments connected to the bus PDR
         """
         return self._connected_to_pdr
+
+    def set_is_field_measurements(self, is_field_measurements: bool) -> None:
+        """Sets if the curves are field measurements.
+        Parameters
+        ----------
+        is_field_measurements: bool
+            True if the curves are field measurements, False otherwise
+        """
+        self._is_field_measurements = is_field_measurements
+
+    def is_field_measurements(self) -> bool:
+        """Checks if the curves are field measurements.
+
+        Returns
+        -------
+        bool
+            True if the curves are field measurements, False otherwise
+        """
+        return self._is_field_measurements

--- a/src/dycov/report/report.py
+++ b/src/dycov/report/report.py
@@ -155,7 +155,7 @@ def _pcs_replace(
         solver_map = solver.create_map(oc_results)
         results_map = results.create_map(oc_results)
         compliance_map = compliance.create_map(oc_results)
-        thresholds_map = thresholds.create_map(oc_results, producer.is_dynawo_model())
+        thresholds_map = thresholds.create_map(oc_results, producer.is_field_measurements())
         error_map = signal_error.create_map(oc_results)
         steady_state_error_map = steady_state_error.create_map(oc_results)
         time_error_map = characteristics_response.create_map(oc_results)


### PR DESCRIPTION
There are two distinct KPI sets: one for simulation and another for field tests. The bug stemmed from calculations being performed with the simulation set, while the threshold values displayed in the PDF were those from the field test set, which are more permissive.