### PR TITLE
Force voltage droop

### DIFF
--- a/src/dycov/configuration/defaultConfig.ini
+++ b/src/dycov/configuration/defaultConfig.ini
@@ -381,6 +381,33 @@ HTB1_Scc = 400
 HTB2_Scc = 1500
 HTB3_Scc = 7000
 
+# Configuration flags for the voltage droop mode of the generator
+# Sections by classes of benchmarks [VoltageDroop]
+# by family [WECC, IEC]
+# and by zone [Plant, Turbine]
+
+# It is possible to use the control_option parameter to configure the default
+# voltage droop mode to use, this parameter expects an integer as a value, in each
+# section the available options and the associated value are shown.
+
+# WECC Plant Voltage Droop Modes
+[VoltageDroop_WECC_Plant]
+RefFlag = True
+VCompFlag = False
+# * for VoltageDroop_WECC_Plant
+#       - control_option = 1
+#           RefFlag = True
+#           VCompFlag = False
+
+# IEC Plant Voltage Droop Modes
+[VoltageDroop_IEC_Plant]
+MqG = 0
+MwpqMode = 3
+# * for VoltageDroop_IEC_Plant
+#       - control_option = 1
+#           MqG = 0
+#           MwpqMode = 3
+
 # Configuration flags for the control mode of the generator
 # Sections by classes of benchmarks [USetpoint, QSetpoint, PSetpoint, Others]
 # by family [WECC, IEC]

--- a/src/dycov/dynawo/curves.py
+++ b/src/dycov/dynawo/curves.py
@@ -318,7 +318,7 @@ class DynawoCurves(ProducerCurves):
         # Modify producer par to add generator init values
         section = get_cfg_oc_name(pcs_bm_name, oc_name)
         control_mode = config.get_value(section, "setpoint_change_test_type")
-        force_voltage_droop = config.get_boolean(section, "force_voltage_droop", False)
+        force_voltage_droop = config.get_boolean(self._pcs_name, "force_voltage_droop", False)
         model_parameters.adjust_producer_init(
             working_oc_dir,
             self.get_producer().get_producer_par(),

--- a/src/dycov/dynawo/translator.py
+++ b/src/dycov/dynawo/translator.py
@@ -272,18 +272,52 @@ class Translator:
         return self._get_control_mode_parameters(control_mode)
 
     def is_valid_control_mode(
-        self, generator: Gen_params, generator_control_mode: str, generator_parameters: dict
-    ) -> bool:
+        self, generator: Gen_params, generator_control_mode: str, control_mode_parameters: dict
+    ) -> str:
+        """Check if the control mode is valid for the generator.
+
+        Parameters
+        ----------
+        generator: Gen_params
+            Generator parameters
+        generator_control_mode: str
+            Control mode name
+        control_mode_parameters: dict
+            Control mode parameters
+
+        Returns
+        -------
+        str
+            Valid control mode name or empty string if not valid
+        """
 
         valid_control_modes = self._get_control_modes_by_generator(
             generator, generator_control_mode
         )
         for control_mode in valid_control_modes:
             valid_parameters = self._get_control_mode_parameters(control_mode)
-            if _is_valid_control_mode_parameters(generator_parameters, valid_parameters):
-                return True
+            if _is_valid_control_mode_parameters(control_mode_parameters, valid_parameters):
+                return control_mode
 
-        return False
+        return ""
+
+    def is_reactive_control_mode(self, generator: Gen_params, control_mode_name: str) -> bool:
+        """Check if the control mode is a reactive control mode.
+
+        Parameters
+        ----------
+        generator: Gen_params
+            Generator parameters
+        control_mode_name: str
+            Control mode name
+
+        Returns
+        -------
+        bool
+            True if the control mode is a reactive control mode, False otherwise
+        """
+        valid_control_modes = self._get_control_modes_by_generator(generator, "QSetpoint")
+        return True if control_mode_name in valid_control_modes else False
 
 
 def _get_instance() -> Translator:

--- a/src/dycov/files/model_parameters.py
+++ b/src/dycov/files/model_parameters.py
@@ -434,15 +434,12 @@ def _set_voltage_droop(generator, parset, ns, generator_control_mode, force_volt
             if dynawo_translator.is_valid_control_mode(
                 generator, "VoltageDroop", default_voltage_droop_parameters
             ):
-                print(f"\tgenerator {generator.id} Forced")
                 _set_parameters(generator, parset, ns, default_voltage_droop_parameters)
             else:
                 dycov_logging.get_logger("Model Parameters").error(
                     f"{generator.lib} executed with wrong voltage droop mode"
                 )
                 raise ValueError(f"{generator.lib} executed with wrong voltage droop mode")
-        else:
-            print(f"\tgenerator {generator.id} in voltage droop mode")
 
     _recalculate_voltage_ref(generator, voltage_droop_parameters)
 

--- a/src/dycov/files/model_parameters.py
+++ b/src/dycov/files/model_parameters.py
@@ -386,7 +386,9 @@ def _adjust_generator(
     _, phase0 = dynawo_translator.get_dynawo_variable(generator.lib, "Phase0")
     _set_parameter(parset, ns, phase0, sign, generator_uphase0)
 
-    _set_control_mode(generator, parset, ns, generator_control_mode)
+    force_voltage_droop = _set_control_mode(
+        generator, parset, ns, generator_control_mode, force_voltage_droop
+    )
 
     _set_voltage_droop(generator, parset, ns, generator_control_mode, force_voltage_droop)
 
@@ -412,10 +414,9 @@ def _set_voltage_droop(generator, parset, ns, generator_control_mode, force_volt
     )
     # If the generator has not voltage droop parameters return, like NonPlant Controller units.
     if not voltage_droop_parameters:
-        return
+        force_voltage_droop = False
 
-    if generator_control_mode == "USetpoint" and force_voltage_droop:
-
+    if force_voltage_droop:
         # Check if the configured voltage droop is valid
         if not dynawo_translator.is_valid_control_mode(
             generator, "VoltageDroop", voltage_droop_parameters
@@ -433,17 +434,20 @@ def _set_voltage_droop(generator, parset, ns, generator_control_mode, force_volt
             if dynawo_translator.is_valid_control_mode(
                 generator, "VoltageDroop", default_voltage_droop_parameters
             ):
+                print(f"\tgenerator {generator.id} Forced")
                 _set_parameters(generator, parset, ns, default_voltage_droop_parameters)
             else:
                 dycov_logging.get_logger("Model Parameters").error(
                     f"{generator.lib} executed with wrong voltage droop mode"
                 )
                 raise ValueError(f"{generator.lib} executed with wrong voltage droop mode")
+        else:
+            print(f"\tgenerator {generator.id} in voltage droop mode")
 
     _recalculate_voltage_ref(generator, voltage_droop_parameters)
 
 
-def _set_control_mode(generator, parset, ns, generator_control_mode) -> None:
+def _set_control_mode(generator, parset, ns, generator_control_mode, force_voltage_droop) -> bool:
     if generator_control_mode == "USetpoint" or generator_control_mode == "QSetpoint":
         # Get the generator control mode parameters from the producer PAR file.
         control_mode_parameters = _get_control_mode_parameters(generator, parset, ns)
@@ -455,9 +459,10 @@ def _set_control_mode(generator, parset, ns, generator_control_mode) -> None:
             return
 
         # Check if the configured control mode is valid
-        if not dynawo_translator.is_valid_control_mode(
+        control_mode_name = dynawo_translator.is_valid_control_mode(
             generator, generator_control_mode, control_mode_parameters
-        ):
+        )
+        if not control_mode_name:
             dycov_logging.get_logger("Model Parameters").warning(
                 f"{generator.lib} control mode will be changed"
             )
@@ -468,9 +473,10 @@ def _set_control_mode(generator, parset, ns, generator_control_mode) -> None:
                 f"Default Control Mode: {default_control_mode_parameters} "
                 f"for {generator_control_mode}"
             )
-            if dynawo_translator.is_valid_control_mode(
+            control_mode_name = dynawo_translator.is_valid_control_mode(
                 generator, generator_control_mode, default_control_mode_parameters
-            ):
+            )
+            if control_mode_name:
                 _set_parameters(generator, parset, ns, default_control_mode_parameters)
             else:
                 dycov_logging.get_logger("Model Parameters").error(
@@ -478,7 +484,13 @@ def _set_control_mode(generator, parset, ns, generator_control_mode) -> None:
                 )
                 raise ValueError(f"{generator.lib} executed with wrong control mode")
 
-    return
+        # If the control mode is reactive, disable voltage droop
+        if control_mode_name:
+            force_voltage_droop = not dynawo_translator.is_reactive_control_mode(
+                generator, control_mode_name
+            )
+
+    return force_voltage_droop
 
 
 def _get_voltage_droop_parameters(generator, parset, ns) -> dict:

--- a/src/dycov/files/model_parameters.py
+++ b/src/dycov/files/model_parameters.py
@@ -386,11 +386,13 @@ def _adjust_generator(
     _, phase0 = dynawo_translator.get_dynawo_variable(generator.lib, "Phase0")
     _set_parameter(parset, ns, phase0, sign, generator_uphase0)
 
-    force_voltage_droop = _set_control_mode(
+    control_mode_name = _set_control_mode(
         generator, parset, ns, generator_control_mode, force_voltage_droop
     )
 
-    _set_voltage_droop(generator, parset, ns, generator_control_mode, force_voltage_droop)
+    _set_voltage_droop(
+        generator, parset, ns, generator_control_mode, control_mode_name, force_voltage_droop
+    )
 
 
 def _recalculate_voltage_ref(generator, voltage_droop_parameters) -> None:
@@ -406,7 +408,9 @@ def _recalculate_voltage_ref(generator, voltage_droop_parameters) -> None:
         generator.UseVoltageDroop = True
 
 
-def _set_voltage_droop(generator, parset, ns, generator_control_mode, force_voltage_droop) -> None:
+def _set_voltage_droop(
+    generator, parset, ns, generator_control_mode, control_mode_name, force_voltage_droop
+) -> None:
     # Get the generator voltage droop parameters from the producer PAR file.
     voltage_droop_parameters = _get_voltage_droop_parameters(generator, parset, ns)
     dycov_logging.get_logger("Model Parameters").debug(
@@ -415,6 +419,12 @@ def _set_voltage_droop(generator, parset, ns, generator_control_mode, force_volt
     # If the generator has not voltage droop parameters return, like NonPlant Controller units.
     if not voltage_droop_parameters:
         force_voltage_droop = False
+
+    # If the control mode is reactive, disable voltage droop
+    if control_mode_name:
+        force_voltage_droop = not dynawo_translator.is_reactive_control_mode(
+            generator, control_mode_name
+        )
 
     if force_voltage_droop:
         # Check if the configured voltage droop is valid
@@ -444,21 +454,21 @@ def _set_voltage_droop(generator, parset, ns, generator_control_mode, force_volt
     _recalculate_voltage_ref(generator, voltage_droop_parameters)
 
 
-def _set_control_mode(generator, parset, ns, generator_control_mode, force_voltage_droop) -> bool:
+def _set_control_mode(generator, parset, ns, generator_control_mode, force_voltage_droop) -> str:
+    control_mode_parameters = _get_control_mode_parameters(generator, parset, ns)
+    dycov_logging.get_logger("Model Parameters").debug(
+        f"Generator {generator.id} Control Mode: {control_mode_parameters}"
+    )
+    # If the generator has not control mode parameters return.
+    if not control_mode_parameters:
+        return
+
+    # Check if the configured control mode is valid
+    control_mode_name = dynawo_translator.is_valid_control_mode(
+        generator, generator_control_mode, control_mode_parameters
+    )
     if generator_control_mode == "USetpoint" or generator_control_mode == "QSetpoint":
         # Get the generator control mode parameters from the producer PAR file.
-        control_mode_parameters = _get_control_mode_parameters(generator, parset, ns)
-        dycov_logging.get_logger("Model Parameters").debug(
-            f"Generator {generator.id} Control Mode: {control_mode_parameters}"
-        )
-        # If the generator has not control mode parameters return.
-        if not control_mode_parameters:
-            return
-
-        # Check if the configured control mode is valid
-        control_mode_name = dynawo_translator.is_valid_control_mode(
-            generator, generator_control_mode, control_mode_parameters
-        )
         if not control_mode_name:
             dycov_logging.get_logger("Model Parameters").warning(
                 f"{generator.lib} control mode will be changed"
@@ -481,13 +491,7 @@ def _set_control_mode(generator, parset, ns, generator_control_mode, force_volta
                 )
                 raise ValueError(f"{generator.lib} executed with wrong control mode")
 
-        # If the control mode is reactive, disable voltage droop
-        if control_mode_name:
-            force_voltage_droop = not dynawo_translator.is_reactive_control_mode(
-                generator, control_mode_name
-            )
-
-    return force_voltage_droop
+    return control_mode_name
 
 
 def _get_voltage_droop_parameters(generator, parset, ns) -> dict:

--- a/src/dycov/templates/PCS/model/BESS/PCS_RTE-I16z1/PCSDescription.ini
+++ b/src/dycov/templates/PCS/model/BESS/PCS_RTE-I16z1/PCSDescription.ini
@@ -5,6 +5,9 @@ report_name = report.RTE-I16z1.tex
 id = 16
 # PCS Zone
 zone = 1
+# Force to configure Voltage Droop Mode
+# (Applies to all tests except QSetpoint type, generating units without Plant Controller or generating units with reactive power control activated)
+force_voltage_droop = false
 
 [PCS-Benchmarks]
 PCS_RTE-I16z1 = ThreePhaseFault,SetPointStep,GridFreqRamp,GridVoltageStep
@@ -34,9 +37,6 @@ bolted_fault = true
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z1.ThreePhaseFault.TransientBoltedSCR3Injection.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -88,9 +88,6 @@ bolted_fault = true
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z1.ThreePhaseFault.TransientBoltedSCR10Injection.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -142,9 +139,6 @@ bolted_fault = true
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z1.ThreePhaseFault.TransientBoltedSCR3QminInjection.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -196,9 +190,6 @@ bolted_fault = false
 hiz_fault = true
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z1.ThreePhaseFault.TransientHiZTc800Injection.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -252,9 +243,6 @@ bolted_fault = false
 hiz_fault = true
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z1.ThreePhaseFault.TransientHiZTc500Injection.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -308,9 +296,6 @@ bolted_fault = true
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z1.ThreePhaseFault.PermanentBoltedInjection.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -362,9 +347,6 @@ bolted_fault = false
 hiz_fault = true
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z1.ThreePhaseFault.PermanentHiZInjection.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -418,9 +400,6 @@ bolted_fault = true
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z1.ThreePhaseFault.TransientBoltedSCR3Consumption.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -472,9 +451,6 @@ bolted_fault = true
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z1.ThreePhaseFault.TransientBoltedSCR10Consumption.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -526,9 +502,6 @@ bolted_fault = true
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z1.ThreePhaseFault.TransientBoltedSCR3QminConsumption.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -580,9 +553,6 @@ bolted_fault = false
 hiz_fault = true
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z1.ThreePhaseFault.TransientHiZTc800Consumption.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -636,9 +606,6 @@ bolted_fault = false
 hiz_fault = true
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z1.ThreePhaseFault.TransientHiZTc500Consumption.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -692,9 +659,6 @@ bolted_fault = true
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z1.ThreePhaseFault.PermanentBoltedConsumption.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -746,9 +710,6 @@ bolted_fault = false
 hiz_fault = true
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z1.ThreePhaseFault.PermanentHiZConsumption.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -810,9 +771,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z1.GridFreqRamp.W500mHz250msInjection.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -862,9 +820,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z1.GridFreqRamp.W500mHz250msConsumption.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -922,9 +877,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = PSetpoint
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z1.SetPointStep.ActiveInjection.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -974,9 +926,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = QSetpoint
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z1.SetPointStep.ReactiveInjection.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -1026,9 +975,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = USetpoint
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z1.SetPointStep.VoltageInjection.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -1078,9 +1024,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = PSetpoint
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z1.SetPointStep.ActiveConsumption.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -1130,9 +1073,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = QSetpoint
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z1.SetPointStep.ReactiveConsumption.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -1182,9 +1122,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = USetpoint
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z1.SetPointStep.VoltageConsumption.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -1242,9 +1179,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z1.GridVoltageStep.RiseInjection.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -1296,9 +1230,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z1.GridVoltageStep.DropInjection.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -1350,9 +1281,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z1.GridVoltageStep.RiseConsumption.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -1404,9 +1332,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z1.GridVoltageStep.DropConsumption.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 

--- a/src/dycov/templates/PCS/model/BESS/PCS_RTE-I16z3/PCSDescription.ini
+++ b/src/dycov/templates/PCS/model/BESS/PCS_RTE-I16z3/PCSDescription.ini
@@ -5,6 +5,9 @@ report_name = report.RTE-I16z3.tex
 id = 16
 # PCS Zone
 zone = 3
+# Force to configure Voltage Droop Mode
+# (Applies to all tests except QSetpoint type, generating units without Plant Controller or generating units with reactive power control activated)
+force_voltage_droop = true
 
 [PCS-Benchmarks]
 PCS_RTE-I16z3 = USetPointStep,PSetPointStep,QSetPointStep,ThreePhaseFault,GridVoltageDip,GridVoltageSwell,Islanding
@@ -37,9 +40,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = USetpoint
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = true
 
 [PCS_RTE-I16z3.USetPointStep.AReactanceInjection.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -89,9 +89,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = USetpoint
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = true
 
 [PCS_RTE-I16z3.USetPointStep.BReactanceInjection.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -142,9 +139,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = USetpoint
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = true
 
 [PCS_RTE-I16z3.USetPointStep.AReactanceConsumption.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -194,9 +188,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = USetpoint
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = true
 
 [PCS_RTE-I16z3.USetPointStep.BReactanceConsumption.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -254,9 +245,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = PSetpoint
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z3.PSetPointStep.Dec40Injection.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -306,9 +294,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = PSetpoint
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z3.PSetPointStep.Inc40Injection.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -358,9 +343,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = PSetpoint
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z3.PSetPointStep.Dec40Consumption.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -410,9 +392,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = PSetpoint
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z3.PSetPointStep.Inc40Consumption.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -470,9 +449,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = QSetpoint
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z3.QSetPointStep.Inc10Injection.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -522,9 +498,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = QSetpoint
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z3.QSetPointStep.Dec20Injection.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -574,9 +547,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = QSetpoint
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z3.QSetPointStep.Inc10Consumption.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -626,9 +596,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = QSetpoint
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z3.QSetPointStep.Dec20Consumption.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -686,9 +653,6 @@ bolted_fault = true
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z3.ThreePhaseFault.TransientBoltedInjection.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -744,9 +708,6 @@ bolted_fault = true
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z3.ThreePhaseFault.TransientBoltedConsumption.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -814,9 +775,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z3.GridVoltageDip.QzeroInjection.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -896,9 +854,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z3.GridVoltageDip.QzeroConsumption.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -979,9 +934,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z3.GridVoltageSwell.QMaxInjection.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -1049,9 +1001,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z3.GridVoltageSwell.QMinInjection.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -1119,9 +1068,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z3.GridVoltageSwell.QMaxConsumption.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -1189,9 +1135,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z3.GridVoltageSwell.QMinConsumption.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -1267,9 +1210,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z3.Islanding.DeltaP10DeltaQ4Injection.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -1329,9 +1269,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z3.Islanding.DeltaP10DeltaQ4Consumption.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 

--- a/src/dycov/templates/PCS/model/PPM/PCS_RTE-I16z1/PCSDescription.ini
+++ b/src/dycov/templates/PCS/model/PPM/PCS_RTE-I16z1/PCSDescription.ini
@@ -5,6 +5,9 @@ report_name = report.RTE-I16z1.tex
 id = 16
 # PCS Zone
 zone = 1
+# Force to configure Voltage Droop Mode
+# (Applies to all tests except QSetpoint type, generating units without Plant Controller or generating units with reactive power control activated)
+force_voltage_droop = false
 
 [PCS-Benchmarks]
 PCS_RTE-I16z1 = ThreePhaseFault,SetPointStep,GridFreqRamp,GridVoltageStep
@@ -34,9 +37,6 @@ bolted_fault = true
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z1.ThreePhaseFault.TransientBoltedSCR3.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -88,9 +88,6 @@ bolted_fault = true
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z1.ThreePhaseFault.TransientBoltedSCR10.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -142,9 +139,6 @@ bolted_fault = true
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z1.ThreePhaseFault.TransientBoltedSCR3Qmin.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -196,9 +190,6 @@ bolted_fault = false
 hiz_fault = true
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z1.ThreePhaseFault.TransientHiZTc800.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -252,9 +243,6 @@ bolted_fault = false
 hiz_fault = true
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z1.ThreePhaseFault.TransientHiZTc500.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -308,9 +296,6 @@ bolted_fault = true
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z1.ThreePhaseFault.PermanentBolted.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -362,9 +347,6 @@ bolted_fault = false
 hiz_fault = true
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z1.ThreePhaseFault.PermanentHiZ.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -426,9 +408,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z1.GridFreqRamp.W500mHz250ms.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -486,9 +465,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = PSetpoint
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z1.SetPointStep.Active.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -538,9 +514,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = QSetpoint
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z1.SetPointStep.Reactive.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -590,9 +563,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = USetpoint
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z1.SetPointStep.Voltage.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -650,9 +620,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z1.GridVoltageStep.Rise.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -704,9 +671,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z1.GridVoltageStep.Drop.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 

--- a/src/dycov/templates/PCS/model/PPM/PCS_RTE-I16z3/PCSDescription.ini
+++ b/src/dycov/templates/PCS/model/PPM/PCS_RTE-I16z3/PCSDescription.ini
@@ -5,6 +5,9 @@ report_name = report.RTE-I16z3.tex
 id = 16
 # PCS Zone
 zone = 3
+# Force to configure Voltage Droop Mode
+# (Applies to all tests except QSetpoint type, generating units without Plant Controller or generating units with reactive power control activated)
+force_voltage_droop = true
 
 [PCS-Benchmarks]
 PCS_RTE-I16z3 = USetPointStep,PSetPointStep,QSetPointStep,ThreePhaseFault,GridVoltageDip,GridVoltageSwell,Islanding
@@ -37,9 +40,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = USetpoint
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = true
 
 [PCS_RTE-I16z3.USetPointStep.AReactance.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -89,9 +89,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = USetpoint
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = true
 
 [PCS_RTE-I16z3.USetPointStep.BReactance.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -149,9 +146,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = PSetpoint
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z3.PSetPointStep.Dec40.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -201,9 +195,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = PSetpoint
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z3.PSetPointStep.Inc40.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -261,9 +252,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = QSetpoint
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z3.QSetPointStep.Inc10.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -313,9 +301,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = QSetpoint
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z3.QSetPointStep.Dec20.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -373,9 +358,6 @@ bolted_fault = true
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z3.ThreePhaseFault.TransientBolted.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -443,9 +425,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z3.GridVoltageDip.Qzero.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -538,9 +517,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z3.GridVoltageSwell.QMax.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -608,9 +584,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z3.GridVoltageSwell.QMin.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -686,9 +659,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I16z3.Islanding.DeltaP10DeltaQ4.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 

--- a/src/dycov/templates/PCS/performance/BESS/PCS_RTE-I10/PCSDescription.ini
+++ b/src/dycov/templates/PCS/performance/BESS/PCS_RTE-I10/PCSDescription.ini
@@ -3,6 +3,9 @@
 report_name = report.RTE-I10.tex
 # PCS Id, Used to sort the final report
 id = 10
+# Force to configure Voltage Droop Mode
+# (Applies to all tests except QSetpoint type, generating units without Plant Controller or generating units with reactive power control activated)
+force_voltage_droop = false
 
 [PCS-Benchmarks]
 PCS_RTE-I10 = Islanding
@@ -29,9 +32,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I10.Islanding.DeltaP10DeltaQ4Injection.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -91,9 +91,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I10.Islanding.DeltaP10DeltaQ4Consumption.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 

--- a/src/dycov/templates/PCS/performance/BESS/PCS_RTE-I2/PCSDescription.ini
+++ b/src/dycov/templates/PCS/performance/BESS/PCS_RTE-I2/PCSDescription.ini
@@ -3,6 +3,9 @@
 report_name = report.RTE-I2.tex
 # PCS Id, Used to sort the final report
 id = 2
+# Force to configure Voltage Droop Mode
+# (Applies to all tests except QSetpoint type, generating units without Plant Controller or generating units with reactive power control activated)
+force_voltage_droop = true
 
 [PCS-Benchmarks]
 PCS_RTE-I2 = USetPointStep
@@ -29,9 +32,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = USetpoint
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = true
 
 [PCS_RTE-I2.USetPointStep.AReactanceInjection.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -81,9 +81,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = USetpoint
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = true
 
 [PCS_RTE-I2.USetPointStep.BReactanceInjection.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -133,9 +130,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = USetpoint
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = true
 
 [PCS_RTE-I2.USetPointStep.AReactanceConsumption.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -185,9 +179,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = USetpoint
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = true
 
 [PCS_RTE-I2.USetPointStep.BReactanceConsumption.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 

--- a/src/dycov/templates/PCS/performance/BESS/PCS_RTE-I5/PCSDescription.ini
+++ b/src/dycov/templates/PCS/performance/BESS/PCS_RTE-I5/PCSDescription.ini
@@ -3,6 +3,9 @@
 report_name = report.RTE-I5.tex
 # PCS Id, Used to sort the final report
 id = 5
+# Force to configure Voltage Droop Mode
+# (Applies to all tests except QSetpoint type, generating units without Plant Controller or generating units with reactive power control activated)
+force_voltage_droop = false
 
 [PCS-Benchmarks]
 PCS_RTE-I5 = ThreePhaseFault
@@ -29,9 +32,6 @@ bolted_fault = true
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I5.ThreePhaseFault.TransientBoltedInjection.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -87,9 +87,6 @@ bolted_fault = true
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I5.ThreePhaseFault.TransientBoltedConsumption.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 

--- a/src/dycov/templates/PCS/performance/BESS/PCS_RTE-I6/PCSDescription.ini
+++ b/src/dycov/templates/PCS/performance/BESS/PCS_RTE-I6/PCSDescription.ini
@@ -3,6 +3,9 @@
 report_name = report.RTE-I6.tex
 # PCS Id, Used to sort the final report
 id = 6
+# Force to configure Voltage Droop Mode
+# (Applies to all tests except QSetpoint type, generating units without Plant Controller or generating units with reactive power control activated)
+force_voltage_droop = false
 
 [PCS-Benchmarks]
 PCS_RTE-I6 = GridVoltageDip
@@ -33,9 +36,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I6.GridVoltageDip.QzeroInjection.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -115,9 +115,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I6.GridVoltageDip.QzeroConsumption.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 

--- a/src/dycov/templates/PCS/performance/BESS/PCS_RTE-I7/PCSDescription.ini
+++ b/src/dycov/templates/PCS/performance/BESS/PCS_RTE-I7/PCSDescription.ini
@@ -3,6 +3,9 @@
 report_name = report.RTE-I7.tex
 # PCS Id, Used to sort the final report
 id = 7
+# Force to configure Voltage Droop Mode
+# (Applies to all tests except QSetpoint type, generating units without Plant Controller or generating units with reactive power control activated)
+force_voltage_droop = false
 
 [PCS-Benchmarks]
 PCS_RTE-I7 = GridVoltageSwell
@@ -33,9 +36,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I7.GridVoltageSwell.QMaxInjection.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -103,9 +103,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I7.GridVoltageSwell.QMinInjection.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -173,9 +170,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I7.GridVoltageSwell.QMaxConsumption.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -243,9 +237,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I7.GridVoltageSwell.QMinConsumption.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 

--- a/src/dycov/templates/PCS/performance/PPM/PCS_RTE-I10/PCSDescription.ini
+++ b/src/dycov/templates/PCS/performance/PPM/PCS_RTE-I10/PCSDescription.ini
@@ -3,6 +3,9 @@
 report_name = report.RTE-I10.tex
 # PCS Id, Used to sort the final report
 id = 10
+# Force to configure Voltage Droop Mode
+# (Applies to all tests except QSetpoint type, generating units without Plant Controller or generating units with reactive power control activated)
+force_voltage_droop = false
 
 [PCS-Benchmarks]
 PCS_RTE-I10 = Islanding
@@ -29,9 +32,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I10.Islanding.DeltaP10DeltaQ4.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 

--- a/src/dycov/templates/PCS/performance/PPM/PCS_RTE-I2/PCSDescription.ini
+++ b/src/dycov/templates/PCS/performance/PPM/PCS_RTE-I2/PCSDescription.ini
@@ -3,6 +3,9 @@
 report_name = report.RTE-I2.tex
 # PCS Id, Used to sort the final report
 id = 2
+# Force to configure Voltage Droop Mode
+# (Applies to all tests except QSetpoint type, generating units without Plant Controller or generating units with reactive power control activated)
+force_voltage_droop = true
 
 [PCS-Benchmarks]
 PCS_RTE-I2 = USetPointStep
@@ -29,9 +32,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = USetpoint
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = true
 
 [PCS_RTE-I2.USetPointStep.AReactance.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -81,9 +81,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = USetpoint
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = true
 
 [PCS_RTE-I2.USetPointStep.BReactance.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 

--- a/src/dycov/templates/PCS/performance/PPM/PCS_RTE-I5/PCSDescription.ini
+++ b/src/dycov/templates/PCS/performance/PPM/PCS_RTE-I5/PCSDescription.ini
@@ -3,6 +3,9 @@
 report_name = report.RTE-I5.tex
 # PCS Id, Used to sort the final report
 id = 5
+# Force to configure Voltage Droop Mode
+# (Applies to all tests except QSetpoint type, generating units without Plant Controller or generating units with reactive power control activated)
+force_voltage_droop = false
 
 [PCS-Benchmarks]
 PCS_RTE-I5 = ThreePhaseFault
@@ -29,9 +32,6 @@ bolted_fault = true
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I5.ThreePhaseFault.TransientBolted.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 

--- a/src/dycov/templates/PCS/performance/PPM/PCS_RTE-I6/PCSDescription.ini
+++ b/src/dycov/templates/PCS/performance/PPM/PCS_RTE-I6/PCSDescription.ini
@@ -3,6 +3,9 @@
 report_name = report.RTE-I6.tex
 # PCS Id, Used to sort the final report
 id = 6
+# Force to configure Voltage Droop Mode
+# (Applies to all tests except QSetpoint type, generating units without Plant Controller or generating units with reactive power control activated)
+force_voltage_droop = false
 
 [PCS-Benchmarks]
 PCS_RTE-I6 = GridVoltageDip
@@ -33,9 +36,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I6.GridVoltageDip.Qzero.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 

--- a/src/dycov/templates/PCS/performance/PPM/PCS_RTE-I7/PCSDescription.ini
+++ b/src/dycov/templates/PCS/performance/PPM/PCS_RTE-I7/PCSDescription.ini
@@ -3,6 +3,9 @@
 report_name = report.RTE-I7.tex
 # PCS Id, Used to sort the final report
 id = 7
+# Force to configure Voltage Droop Mode
+# (Applies to all tests except QSetpoint type, generating units without Plant Controller or generating units with reactive power control activated)
+force_voltage_droop = false
 
 [PCS-Benchmarks]
 PCS_RTE-I7 = GridVoltageSwell
@@ -33,9 +36,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I7.GridVoltageSwell.QMax.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -103,9 +103,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I7.GridVoltageSwell.QMin.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 

--- a/src/dycov/templates/PCS/performance/SM/PCS_RTE-I10/PCSDescription.ini
+++ b/src/dycov/templates/PCS/performance/SM/PCS_RTE-I10/PCSDescription.ini
@@ -3,6 +3,9 @@
 report_name = report.RTE-I10.tex
 # PCS Id, Used to sort the final report
 id = 10
+# Force to configure Voltage Droop Mode
+# (Applies to all tests except QSetpoint type, generating units without Plant Controller or generating units with reactive power control activated)
+force_voltage_droop = false
 
 [PCS-Benchmarks]
 PCS_RTE-I10 = Islanding
@@ -29,9 +32,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I10.Islanding.DeltaP10DeltaQ4.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 

--- a/src/dycov/templates/PCS/performance/SM/PCS_RTE-I2/PCSDescription.ini
+++ b/src/dycov/templates/PCS/performance/SM/PCS_RTE-I2/PCSDescription.ini
@@ -3,6 +3,9 @@
 report_name = report.RTE-I2.tex
 # PCS Id, Used to sort the final report
 id = 2
+# Force to configure Voltage Droop Mode
+# (Applies to all tests except QSetpoint type, generating units without Plant Controller or generating units with reactive power control activated)
+force_voltage_droop = true
 
 [PCS-Benchmarks]
 PCS_RTE-I2 = USetPointStep
@@ -29,9 +32,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = USetpoint
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = true
 
 [PCS_RTE-I2.USetPointStep.AReactance.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -81,9 +81,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = USetpoint
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = true
 
 [PCS_RTE-I2.USetPointStep.BReactance.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 

--- a/src/dycov/templates/PCS/performance/SM/PCS_RTE-I3/PCSDescription.ini
+++ b/src/dycov/templates/PCS/performance/SM/PCS_RTE-I3/PCSDescription.ini
@@ -3,6 +3,9 @@
 report_name = report.RTE-I3.tex
 # PCS Id, Used to sort the final report
 id = 3
+# Force to configure Voltage Droop Mode
+# (Applies to all tests except QSetpoint type, generating units without Plant Controller or generating units with reactive power control activated)
+force_voltage_droop = false
 
 [PCS-Benchmarks]
 PCS_RTE-I3 = LineTrip
@@ -29,9 +32,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I3.LineTrip.2BReactance.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 

--- a/src/dycov/templates/PCS/performance/SM/PCS_RTE-I4/PCSDescription.ini
+++ b/src/dycov/templates/PCS/performance/SM/PCS_RTE-I4/PCSDescription.ini
@@ -3,6 +3,9 @@
 report_name = report.RTE-I4.tex
 # PCS Id, Used to sort the final report
 id = 4
+# Force to configure Voltage Droop Mode
+# (Applies to all tests except QSetpoint type, generating units without Plant Controller or generating units with reactive power control activated)
+force_voltage_droop = false
 
 [PCS-Benchmarks]
 PCS_RTE-I4 = ThreePhaseFault
@@ -29,9 +32,6 @@ bolted_fault = true
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I4.ThreePhaseFault.TransientBolted.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 

--- a/src/dycov/templates/PCS/performance/SM/PCS_RTE-I6/PCSDescription.ini
+++ b/src/dycov/templates/PCS/performance/SM/PCS_RTE-I6/PCSDescription.ini
@@ -3,6 +3,9 @@
 report_name = report.RTE-I6.tex
 # PCS Id, Used to sort the final report
 id = 6
+# Force to configure Voltage Droop Mode
+# (Applies to all tests except QSetpoint type, generating units without Plant Controller or generating units with reactive power control activated)
+force_voltage_droop = false
 
 [PCS-Benchmarks]
 PCS_RTE-I6 = GridVoltageDip
@@ -33,9 +36,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I6.GridVoltageDip.Qzero.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 

--- a/src/dycov/templates/PCS/performance/SM/PCS_RTE-I7/PCSDescription.ini
+++ b/src/dycov/templates/PCS/performance/SM/PCS_RTE-I7/PCSDescription.ini
@@ -3,6 +3,9 @@
 report_name = report.RTE-I7.tex
 # PCS Id, Used to sort the final report
 id = 7
+# Force to configure Voltage Droop Mode
+# (Applies to all tests except QSetpoint type, generating units without Plant Controller or generating units with reactive power control activated)
+force_voltage_droop = false
 
 [PCS-Benchmarks]
 PCS_RTE-I7 = GridVoltageSwell
@@ -33,9 +36,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I7.GridVoltageSwell.QMax.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 
@@ -102,9 +102,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 
 [PCS_RTE-I7.GridVoltageSwell.QMin.Model]

--- a/src/dycov/templates/PCS/performance/SM/PCS_RTE-I8/PCSDescription.ini
+++ b/src/dycov/templates/PCS/performance/SM/PCS_RTE-I8/PCSDescription.ini
@@ -3,6 +3,9 @@
 report_name = report.RTE-I8.tex
 # PCS Id, Used to sort the final report
 id = 8
+# Force to configure Voltage Droop Mode
+# (Applies to all tests except QSetpoint type, generating units without Plant Controller or generating units with reactive power control activated)
+force_voltage_droop = false
 
 [PCS-Benchmarks]
 PCS_RTE-I8 = LoadShedDisturbance
@@ -29,9 +32,6 @@ bolted_fault = false
 hiz_fault = false
 # OperatingCondition type
 setpoint_change_test_type = Others
-# Force to configure Voltage Droop Mode
-# (Only applies to USetpoint type tests, and generating units with Plant Controller)
-force_voltage_droop = false
 
 [PCS_RTE-I8.LoadShedDisturbance.PmaxQzero.Model]
 # Uncomment only the desired option (line_XPu, SRC, or Zcc). 

--- a/tests/dycov/files/test_model_parameters.py
+++ b/tests/dycov/files/test_model_parameters.py
@@ -202,4 +202,4 @@ def test_generator_control_mode_selection_and_application(tmp_path, monkeypatch)
     par_root = etree.Element(f"{{{ns}}}root", nsmap={None: ns})
     parset = etree.SubElement(par_root, f"{{{ns}}}set", id="parGen")
     # Should not raise
-    model_parameters._set_control_mode(DummyGen(), parset, ns, "USetpoint")
+    model_parameters._set_control_mode(DummyGen(), parset, ns, "USetpoint", False)


### PR DESCRIPTION
The force_voltage_droop option has been extended to all PCS tests in which voltage control remains active, to maintain consistency across all tests. This would exclude only tests in which, for any reason, voltage control (as such) should be inactive (e.g., Q control, fixed PQ mode, fixed power factor mode, etc.). By default, it remains active in PCS I2 and Zone 3 of I16.