### PR TITLE
Replace AVR -> Voltage Control for Z1

### DIFF
--- a/src/dycov/templates/reports/model/BESS/PCS_RTE-I16z1/commonz1.tex
+++ b/src/dycov/templates/reports/model/BESS/PCS_RTE-I16z1/commonz1.tex
@@ -38,7 +38,7 @@
         over all lines on TSO side.
         \item Reactive current supplied at the connection point: sum of reactive power
         over all lines on TSO side.
-        \item Magnitude controlled by the AVR: modulus of the voltage at the REPC.
+        \item Magnitude controlled by voltage control: modulus of the voltage at the REPC.
         All BESS units are plotted on the same graph.
     \end{itemize}
 
@@ -60,7 +60,7 @@
         \centering
         \includegraphics[width=\textwidth]{fig_Ustator_PCS_RTE-I16z1.\DTRPcs.\OCname}
         \begin{minipage}[t]{0.8\textwidth}
-            \small Magnitude controlled by the AVR, in pu. All BESS
+            \small Magnitude controlled by voltage control, in pu. All BESS
             units are plotted on the same graph. The gray dotted
             line shows the AVR setpoint.
         \end{minipage}

--- a/src/dycov/templates/reports/model/PPM/PCS_RTE-I16z1/commonz1.tex
+++ b/src/dycov/templates/reports/model/PPM/PCS_RTE-I16z1/commonz1.tex
@@ -38,7 +38,7 @@
         over all lines on TSO side.
         \item Reactive current supplied at the connection point: sum of reactive power
         over all lines on TSO side.
-        \item Magnitude controlled by the AVR: modulus of the voltage at the REPC.
+        \item Magnitude controlled by voltage control: modulus of the voltage at the REPC.
         All PPM units are plotted on the same graph.
     \end{itemize}
 
@@ -60,7 +60,7 @@
         \centering
         \includegraphics[width=\textwidth]{fig_Ustator_PCS_RTE-I16z1.\DTRPcs.\OCname}
         \begin{minipage}[t]{0.8\textwidth}
-            \small Magnitude controlled by the AVR, in pu. All PPM
+            \small Magnitude controlled by voltage control, in pu. All PPM
             units are plotted on the same graph. The gray dotted
             line shows the AVR setpoint.
         \end{minipage}


### PR DESCRIPTION
Update the captions for Zone 1 figures to remove any references to Zone 3 equipment (AVR).