### PR TITLE
Fix integration tests

### DIFF
--- a/tests/dycov/utils.py
+++ b/tests/dycov/utils.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -9,6 +10,17 @@ from dycov.validate.validation import Validation
 
 PERFORMANCE = "../../examples/Performance"
 MODEL = "../../examples/Model"
+
+
+def _resolve_dynawo_sh():
+    env_path = os.environ.get("DYNAWOPATH")
+    if env_path:
+        candidate = Path(env_path) / "dynawo.sh"
+        if candidate.exists():
+            return candidate.resolve()
+
+    found = shutil.which("dynawo.sh")
+    return Path(found).resolve() if found else None
 
 
 def execute_tool(producer_model_path, producer_curves_path, reference_curves_path):
@@ -38,8 +50,10 @@ def execute_tool(producer_model_path, producer_curves_path, reference_curves_pat
                 else:
                     sim_type = MODEL_VALIDATION
 
+            dynawo_sh = _resolve_dynawo_sh()
+
             params = ValidationParameters(
-                Path(shutil.which("dynawo.sh")).resolve() if shutil.which("dynawo.sh") else None,
+                dynawo_sh,
                 testpath / producer_model_path if producer_model_path else None,
                 testpath / producer_curves_path if producer_curves_path else None,
                 testpath / reference_curves_path if reference_curves_path else None,

--- a/tests_integration/conftest.py
+++ b/tests_integration/conftest.py
@@ -1,0 +1,41 @@
+import re
+from pathlib import Path
+
+import pytest
+
+
+def _find_latest_dynawo(base_dir="/opt"):
+    base = Path(base_dir)
+
+    # Buscar directorios que sigan el patrón Dynawo_vX.Y.Z_YYYYMMDD
+    pattern = re.compile(r"Dynawo_v[\d\.]+_(\d{8})")
+
+    candidates = []
+    for d in base.iterdir():
+        if d.is_dir():
+            m = pattern.match(d.name)
+            if m:
+                date_str = m.group(1)  # YYYYMMDD
+                candidates.append((date_str, d))
+
+    if not candidates:
+        raise RuntimeError(f"No Dynawo installations found in {base_dir}")
+
+    # Elegir el más reciente por orden lexicográfico YYYYMMDD
+    candidates.sort(key=lambda x: x[0], reverse=True)
+
+    latest_dir = candidates[0][1]
+    dynawo_bin = latest_dir / "dynawo" / "dynawo.sh"
+
+    if not dynawo_bin.exists():
+        raise RuntimeError(f"dynawo.sh not found in: {dynawo_bin}")
+
+    return dynawo_bin.parent  # el directorio donde está dynawo.sh
+
+
+@pytest.fixture
+def dynawo_latest(monkeypatch):
+    """Set DYNAWOPATH to the latest Dynawo installation."""
+    latest_path = _find_latest_dynawo()
+    monkeypatch.setenv("DYNAWOPATH", str(latest_path))
+    return latest_path

--- a/tests_integration/test_performance.py
+++ b/tests_integration/test_performance.py
@@ -2,7 +2,7 @@ from dycov.model.compliance import Compliance
 from tests.dycov.utils import PERFORMANCE, execute_tool
 
 
-def test_perf_sm_model():
+def test_perf_sm_model(dynawo_latest):
     compliance = execute_tool(
         f"{PERFORMANCE}/SingleAux/GeneratorSynchronousFourWindingsTGov1SexsPss2a/Dynawo",
         None,
@@ -21,7 +21,7 @@ def test_perf_sm_model():
     ] == compliance
 
 
-def test_perf_sm_complete():
+def test_perf_sm_complete(dynawo_latest):
     compliance = execute_tool(
         f"{PERFORMANCE}/SingleAuxI/GeneratorSynchronousFourWindingsTGov1SexsPss2a/Dynawo",
         f"{PERFORMANCE}/ProducerCurves/GeneratorSynchronous",
@@ -40,7 +40,7 @@ def test_perf_sm_complete():
     ] == compliance
 
 
-def test_perf_ppm_model():
+def test_perf_ppm_model(dynawo_latest):
     compliance = execute_tool(f"{PERFORMANCE}/SingleAux/WECCB/Dynawo", None, None)
     assert [
         Compliance.NonCompliant,  # 0
@@ -53,7 +53,7 @@ def test_perf_ppm_model():
     ] == compliance
 
 
-def test_perf_ppm_complete():
+def test_perf_ppm_complete(dynawo_latest):
     compliance = execute_tool(
         f"{PERFORMANCE}/SingleAux/IECB2020/Dynawo",
         f"{PERFORMANCE}/ProducerCurves/Wind",

--- a/tests_integration/test_validate_model.py
+++ b/tests_integration/test_validate_model.py
@@ -4,7 +4,7 @@ from tests.dycov.utils import MODEL, execute_tool
 RESOURCES = "./resources"
 
 
-def test_model_validation_wecca_model():
+def test_model_validation_wecca_model(dynawo_latest):
     compliance = execute_tool(
         f"{MODEL}/Wind/WECCA/Dynawo",
         None,
@@ -38,7 +38,7 @@ def test_model_validation_wecca_model():
     ] == compliance
 
 
-def test_model_validation_partial_reference():
+def test_model_validation_partial_reference(dynawo_latest):
     compliance = execute_tool(
         f"{MODEL}/Wind/WECCB/Dynawo",
         None,


### PR DESCRIPTION
# Dynawo Installation Options for Integration Tests

This PR introduces support for running integration tests that depend on an external Dynawo simulator. 
Because Dynawo is not a Python package and must be installed separately, developers need a predictable way to make `dynawo.sh` available. 

ℹ️ **Note:** Integration tests are not executed on CI runners.

Below is a summary of the supported installation options and how the test suite discovers the correct simulator.

## 1. Install Dynawo system‑wide under `/opt` (recommended)
If several Dynawo versions are installed under `/opt` following the official naming scheme:
```bash
/opt/
├── Dynawo_v1.8.0_20251126/
├── Dynawo_v1.8.0_20260107/
└── Dynawo_v1.8.0_20260130/
```
the test suite will automatically detect and use **the most recent version** based on the embedded date (e.g., `_20260130`).
The test fixture locates:
```bash
/opt/Dynawo_vX.Y.Z_YYYYMMDD/dynawo/dynawo.sh
```
and injects this path into the environment for the duration of the test.

##  **2. Set the `DYNAWOPATH` environment variable**
You may point the test suite explicitly to a custom Dynawo installation by setting:
```bash
export DYNAWOPATH=/path/to/dynawo/directory
```

The test harness resolves the executable at:
```bash
$DYNAWOPATH/dynawo.sh
```

This overrides any automatic discovery and is useful for:
- local development with a non-standard install layout,
- testing candidate builds of Dynawo,
- debugging with instrumented binaries.

##  **3. Add Dynawo to the `PATH`**
If `dynawo.sh` is already on your `PATH`, the test suite will fall back to `shutil.which("dynawo.sh")`.
Example:
```bash
export PATH=/path/to/dynawo:$PATH
```

## **Test Resolution Logic**
When a test requires Dynawo, the discovery logic proceeds in this order:
- **`DYNAWOPATH`** (most explicit)
- **Auto‑detection under `/opt/Dynawo_*` (latest version)**
- **`PATH` lookup using `shutil.which("dynawo.sh")`**

This ensures:
- reproducibility in CI,
- flexibility for developers,
- isolation of environment modifications (only inside the test process).
