### PR TITLE
Fix internal line parameter error message

### DIFF
--- a/src/dycov/sanity_checks/parameter_checks.py
+++ b/src/dycov/sanity_checks/parameter_checks.py
@@ -283,7 +283,7 @@ def check_auxiliary_load(load: LoadParams) -> None:
 
 def check_internal_line(line: LineParams) -> None:
     """Check whether the user-supplied internal line parameters are consistent:
-    * The reactance and admittance of the internal line must be greater than zero.
+    * The resistance and reactance of the internal line must be greater than zero.
 
     Parameters
     ----------
@@ -292,7 +292,7 @@ def check_internal_line(line: LineParams) -> None:
     """
     if line and (line.r <= 0 or line.x <= 0):
         raise ValueError(
-            "The reactance and admittance of the internal line must be greater than zero."
+            "The resistance and reactance of the internal line must be greater than zero."
         )
 
 

--- a/tests/dycov/sanity_checks/test_parameter_checks.py
+++ b/tests/dycov/sanity_checks/test_parameter_checks.py
@@ -185,7 +185,7 @@ def test_internal_lines():
     assert pytest_wrapped_e.type is ValueError
     assert (
         pytest_wrapped_e.value.args[0]
-        == "The reactance and admittance of the internal line must be greater than zero."
+        == "The resistance and reactance of the internal line must be greater than zero."
     )
 
 


### PR DESCRIPTION
## Summary

Corrects the internal-line validation documentation and error message to describe the parameters actually checked: resistance and reactance.

## Verification

- `uv run pytest -q tests/dycov/sanity_checks/test_parameter_checks.py -k internal_lines`
- `uv run ruff check src/dycov/sanity_checks/parameter_checks.py tests/dycov/sanity_checks/test_parameter_checks.py`

Fixes #380
