### PR TITLE
Fix missing parameter set detection

### DIFF
--- a/src/dycov/files/model_parameters.py
+++ b/src/dycov/files/model_parameters.py
@@ -1281,9 +1281,7 @@ def _adjust_load(
     load_uphase0: float,
 ) -> None:
     nsmap = {"ns": etree.QName(producer_par_root).namespace}
-    parset = producer_par_root.xpath(f"//ns:set[@id='{load_id}']", namespaces=nsmap)
-    if parset is None:
-        return
+    parset = _get_parset(producer_par_root, load_id, nsmap)
 
     sign, active_power0 = dynawo_translator.get_dynawo_variable(load_lib, "ActivePower0")
     _set_parameter(parset, nsmap, active_power0, sign, load_p0pu, create_if_missing=True)

--- a/src/dycov/files/model_parameters.py
+++ b/src/dycov/files/model_parameters.py
@@ -696,7 +696,7 @@ def _get_connected_equipment_by_terminal(dyd_root, gen_id, terminal):
 
 def _get_parset(par_root, par_id, nsmap):
     parset = par_root.xpath(f"//ns:set[@id='{par_id}']", namespaces=nsmap)
-    if parset is None:
+    if not parset:
         raise ValueError(f"The parameter set with id='{par_id}' was not found")
     return parset
 
@@ -1014,8 +1014,6 @@ def _adjust_transformer(
 ):
     nsmap = {"ns": etree.QName(producer_par_root).namespace}
     parset = _get_parset(producer_par_root, transformer.par_id, nsmap)
-    if parset is None:
-        return
 
     _set_transformer_power(parset, nsmap, transformer.lib, transformer_p10pu, transformer_q10pu)
     _set_transformer_voltage_phase(
@@ -1059,8 +1057,6 @@ def _adjust_generator(
 ) -> int:
     nsmap = {"ns": etree.QName(producer_par_root).namespace}
     parset = _get_parset(producer_par_root, generator.par_id, nsmap)
-    if parset is None:
-        return False
 
     _set_initial_power(parset, nsmap, generator.lib, generator_p0pu, generator_q0pu)
     _set_initial_pcc_power(parset, nsmap, generator.lib, pdr)

--- a/tests/dycov/files/test_model_parameters.py
+++ b/tests/dycov/files/test_model_parameters.py
@@ -79,6 +79,29 @@ def test_get_parset_missing_id_raises():
         model_parameters._get_parset(par_root, "missing", {"ns": _NS})
 
 
+def test_adjust_load_missing_parset_raises():
+    par_root = _make_root()
+
+    with pytest.raises(ValueError, match="parameter set with id='Aux_Load' was not found"):
+        model_parameters._adjust_load(par_root, "Aux_Load", "LoadAlphaBeta", 0.1, 0.05, 1.0, 0.0)
+
+
+def test_adjust_load_writes_initial_values():
+    par_root = _make_root()
+    etree.SubElement(par_root, f"{{{_NS}}}set", id="Aux_Load")
+
+    model_parameters._adjust_load(par_root, "Aux_Load", "LoadAlphaBeta", 0.1, 0.05, 1.0, 0.2)
+
+    parset = par_root.xpath("//ns:set[@id='Aux_Load']", namespaces={"ns": _NS})[0]
+    written = {par.get("name"): float(par.get("value")) for par in parset}
+    assert written == {
+        "load_P0Pu": 0.1,
+        "load_Q0Pu": 0.05,
+        "load_U0Pu": 1.0,
+        "load_UPhase0": 0.2,
+    }
+
+
 def test_extract_defined_value_with_placeholders():
     assert model_parameters.extract_defined_value("2*b", "b", 0.2) == pytest.approx(0.4)
     assert model_parameters.extract_defined_value("pmax", "pmax", 90) == pytest.approx(90)

--- a/tests/dycov/files/test_model_parameters.py
+++ b/tests/dycov/files/test_model_parameters.py
@@ -72,6 +72,13 @@ def test_no_matching_equipment_models(tmp_path):
     assert intline is None
 
 
+def test_get_parset_missing_id_raises():
+    par_root = _make_root()
+
+    with pytest.raises(ValueError, match="parameter set with id='missing' was not found"):
+        model_parameters._get_parset(par_root, "missing", {"ns": _NS})
+
+
 def test_extract_defined_value_with_placeholders():
     assert model_parameters.extract_defined_value("2*b", "b", 0.2) == pytest.approx(0.4)
     assert model_parameters.extract_defined_value("pmax", "pmax", 90) == pytest.approx(90)


### PR DESCRIPTION
## Summary

- treat an empty XPath result as a missing parameter set
- remove the now-unreachable `None` guards from generator and transformer adjustment
- add a regression test for a missing `parId`

Closes #372.

## Verification

- `python -m pytest -q tests/dycov/files/test_model_parameters.py::test_get_parset_missing_id_raises` (1 passed)
- `python -m pytest -q tests/dycov/files/test_model_parameters.py` (13 passed)
- `python -m pytest -q --ignore=tests/dycov/validate/test_validate_model.py --ignore=tests/dycov/validate/test_validate_performance.py` (776 passed, 2 skipped)
- `ruff check src` (passed)
- `python -m build --wheel` (passed)

The complete local `pytest -q` run reached the five long-running multiprocessing validation tests; those five were interrupted after several minutes rather than reported as passing. The remaining 778 tests completed as recorded above.
