### PR TITLE
fix(validate): exit with code 1 when overwrite is declined

### DIFF
--- a/src/dycov/core/initialization.py
+++ b/src/dycov/core/initialization.py
@@ -348,7 +348,7 @@ class DycovInitializer:
         """
         is_aborted = precompile(launcher_dwo)
         if is_aborted:
-            sys.exit()
+            sys.exit(1)
 
     def _check_config_file(self, tool_config_file: Path, user_config_file: Path):
         """

--- a/src/dycov/gfm/generator.py
+++ b/src/dycov/gfm/generator.py
@@ -100,7 +100,7 @@ class GFMGeneration:
                 "Exiting. Please rename your current Results directory, "
                 "otherwise it will be erased and a new one will be created."
             )
-            sys.exit()
+            sys.exit(1)
 
         # Create a fresh output directory once safety is confirmed
         manage_files.create_dir(self._parameters.get_output_dir())

--- a/src/dycov/validate/validation.py
+++ b/src/dycov/validate/validation.py
@@ -178,7 +178,7 @@ class Validation:
                 "Exiting. Please rename your current Results directory, otherwise it will be "
                 "erased and a new one will be created."
             )
-            sys.exit()
+            sys.exit(1)
 
     def __get_validation_pcs(self) -> list:
         """Determines the list of PCS to be validated based on simulation type and configuration.

--- a/tests/dycov/core/test_initialization.py
+++ b/tests/dycov/core/test_initialization.py
@@ -8,6 +8,7 @@
 #     demiguelm@aia.es
 #
 import configparser
+from pathlib import Path
 
 import pytest
 
@@ -324,3 +325,14 @@ class TestDycovInitializer:
             ),  # console_formatter from mock_config
             self.mock_config.get_config_dir.return_value / "log",  # log_dir
         )
+
+    def test_prepare_dynawo_models_exits_on_aborted_precompile(self, dycov_initializer, mocker):
+        """
+        Tests that _prepare_dynawo_models exits with code 1 when precompile aborts.
+        """
+        mocker.patch("dycov.core.initialization.precompile", return_value=True)
+
+        with pytest.raises(SystemExit) as exc_info:
+            dycov_initializer._prepare_dynawo_models(Path("dynawo"))
+
+        assert exc_info.value.code == 1

--- a/tests/dycov/gfm/test_generator.py
+++ b/tests/dycov/gfm/test_generator.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# (c) 2026 RTE
+# Developed by Grupo AIA
+# marinjl@aia.es
+# omsg@aia.es
+# demiguelm@aia.es
+#
+
+import pytest
+
+
+class _DummyParameters:
+    def __init__(self, tmp_path):
+        self._tmp_path = tmp_path
+
+    def get_working_dir(self):
+        return self._tmp_path / "working"
+
+    def get_output_dir(self):
+        return self._tmp_path / "Results"
+
+
+def test_initialize_working_environment_exits_on_existing_output_dir(monkeypatch, tmp_path):
+    from dycov.gfm import generator
+
+    monkeypatch.setattr(generator.manage_files, "create_dir", lambda *a, **k: None)
+    monkeypatch.setattr(generator.manage_files, "check_output_dir", lambda path: True)
+    gfm_generation = object.__new__(generator.GFMGeneration)
+    gfm_generation._parameters = _DummyParameters(tmp_path)
+
+    with pytest.raises(SystemExit) as exc_info:
+        gfm_generation._GFMGeneration__initialize_working_environment()
+
+    assert exc_info.value.code == 1

--- a/tests/dycov/validate/test_validation.py
+++ b/tests/dycov/validate/test_validation.py
@@ -218,5 +218,6 @@ def test_validation_exits_on_existing_output_dir(monkeypatch, temp_dirs):
         "dycov.validate.validation.Pcs",
         lambda producer, name, params: make_valid_pcs(producer, name, params),
     )
-    with pytest.raises(SystemExit):
+    with pytest.raises(SystemExit) as exc_info:
         Validation(parameters)
+    assert exc_info.value.code == 1


### PR DESCRIPTION
## Problem
When a user declines to overwrite an existing output/results directory in `__initialize_working_environment()`, `Validation` called `sys.exit()` with no arguments. This resulted in an exit code of 0, incorrectly indicating success to caller scripts or CI workflows (#381).

## Solution
- In `src/dycov/validate/validation.py`, change `sys.exit()` to `sys.exit(1)` when the output directory check prompts the exit warning.
- In `tests/dycov/validate/test_validation.py:test_validation_exits_on_existing_output_dir`, assert that `exc_info.value.code == 1`.

Fixes #381
