### PR TITLE
fix the input-layout examples and trees in manual and tutorials

### DIFF
--- a/docs/manual/source/examples.rst
+++ b/docs/manual/source/examples.rst
@@ -8,9 +8,9 @@ what DyCoV produces before working with your own data.
 
 All examples live under the ``examples/`` directory at the root of the
 repository. If you installed DyCoV natively on Linux, a copy was placed in
-``~/dycov/examples/`` during installation. If you are using the Docker or WSL
-image, the examples are copied to your home directory the first time you start
-a session.
+``$PWD/dycov/examples/`` (inside the directory the installer was run from).
+If you are using the Docker or WSL image, the examples are copied to your home
+directory the first time you start a session.
 
 
 How the examples are organized
@@ -77,12 +77,16 @@ Using a Dynawo model:
    cd examples/Model/Wind/WECC4B
    dycov validate ReferenceCurves/ -m Dynawo/
 
-Using producer curves instead of a Dynawo model:
+Using producer curves instead of a Dynawo model. ``-c`` must point at the case
+directory — the one containing ``Producer/`` and the per-zone
+``Zone1/``/``Zone3/`` folders. Since the producer-curves example carries no
+reference curves of its own, the reference here is borrowed from the WECC4B
+example:
 
 .. code-block:: console
 
-   cd examples/Model/ProducerCurves/PPM
-   dycov validate ReferenceCurves/ -c ProducerCurves/
+   cd examples/Model
+   dycov validate Wind/WECC4B/ReferenceCurves/ -c ProducerCurves/PPM/
 
 In both cases, DyCoV compares the curves against the reference, evaluates
 compliance, and writes a PDF report and interactive HTML plots under
@@ -102,12 +106,13 @@ Using a Dynawo model:
    cd examples/Performance/Single/WECC4B
    dycov performance -m Dynawo/
 
-Using producer curves:
+Using producer curves. ``-c`` must point at the case directory — the one
+containing ``Producer/`` and ``Producer.ini``:
 
 .. code-block:: console
 
-   cd examples/Performance/ProducerCurves/PPM
-   dycov performance -c ProducerCurves/
+   cd examples/Performance
+   dycov performance -c ProducerCurves/PPM/
 
 Results go to ``Results/`` as well, with the same PDF and HTML structure.
 

--- a/docs/manual/source/index.rst
+++ b/docs/manual/source/index.rst
@@ -76,13 +76,13 @@ recommend reading :ref:`get-started` first.
 Reference
 =========
 
-Quick-access reference for the most frequently consulted information.
+Quick-access reference for the most frequently consulted information: the
+:doc:`examples <examples>`, the :doc:`configuration options
+<usage/configuration>`, the :doc:`input formats <usage/inputs>`, and the CLI
+reference below.
 
 .. toctree::
    :maxdepth: 2
    :caption: Reference
 
-   examples
-   usage/configuration
-   usage/inputs
    usage/cli_reference

--- a/docs/manual/source/usage/inputs.rst
+++ b/docs/manual/source/usage/inputs.rst
@@ -97,8 +97,9 @@ A typical file looks like this:
    :caption: Example GFM Producer INI file
 
    [DEFAULT]
-   # Nominal voltage at the PDR Bus (in kV)
-   Unom = 20.0
+   # Nominal voltage at the PDR bus (in kV)
+   # Allowed values: 400, 225, 150, 90, 63 (land) and 132, 66 (offshore)
+   u_nom = 225
    # Active power limits (in MW)
    p_max_injection = 100.0
    p_min_injection = 0.0
@@ -117,7 +118,10 @@ A typical file looks like this:
    Snom = 110.0
 
 For **Hybrid mode** (combining overdamped and underdamped envelopes), the
-``[GFM Parameters]`` section should instead define separate parameter sets:
+``[GFM Parameters]`` section should instead define separate damping and
+inertia sets — ``Xeff`` is still required, and ``save_all_envelopes`` controls
+whether the intermediate overdamped and underdamped traces are kept in the
+CSV output alongside the merged envelope:
 
 .. code-block:: ini
 
@@ -126,7 +130,9 @@ For **Hybrid mode** (combining overdamped and underdamped envelopes), the
    H_Overdamped = 4.0
    D_Underdamped = 10.0
    H_Underdamped = 2.5
+   Xeff = 0.15
    Snom = 110.0
+   save_all_envelopes = False
 
 .. seealso::
    :ref:`GFM Envelope Generation <gfm_envelopes_cmd>` for a description of
@@ -431,10 +437,18 @@ The guided process works in stages:
 
    .. code-block:: ini
 
+      # p_{max_unite} injection as defined by the DTR in MW (expected value >= 0.0)
       p_max_injection_at_PDR =
-      u_nom =
+      # p_{max_unite} consumption as defined by the DTR in MW (only for BESS)
+      p_max_consumption_at_PDR =
+      # u_nom is the nominal voltage at the PDR bus (in kV)
+      # Allowed values: 400, 225, 150, 90, 63 (land) and 132, 66 (offshore)
+      u_nom_at_PDR =
+      # q_max is the maximum reactive power at the PDR bus (in MVar)
       q_max_at_PDR =
+      # q_min is the minimum reactive power at the PDR bus (in MVar)
       q_min_at_PDR =
+      # topology
       topology = S+Aux
 
 4. **Curve files** — DyCoV creates a ``ReferenceCurves/`` directory with a

--- a/docs/manual/source/usage/validations.rst
+++ b/docs/manual/source/usage/validations.rst
@@ -19,12 +19,11 @@ to the DTR's PCS structure. The following tests are currently implemented:
 * **RMS model validation (Power Parks)**: PCS I16, structured into:
 
   - *Zone 1* (unit-level): Fault Ride-Through, Step Response to Control
-    Setpoints, Ramp Response to Grid Frequency, and Step Response to Grid
-    Voltage.
+    Setpoints, and Step Response to Grid Voltage.
 
   - *Zone 3* (plant-level): Stability of Controls (like I2), Fault
     Ride-Through (like I5), V-sag Ride-Through (like I6), V-surge Ride-Through
-    (like I7), and Islanding (like I10).
+    (like I7), Ramp Response to Grid Frequency, and Islanding (like I10).
 
 * **Electrical performance (Power Park Modules)**: PCSs I2, I5, I6, I7, and I10.
 
@@ -48,8 +47,8 @@ Conceptual structuring of the tests
 -------------------------------------
 
 .. note::
-Please do not skip this section: understanding these concepts will help
-you learn the tool and navigate the results much faster!
+   Please do not skip this section: understanding these concepts will help
+   you learn the tool and navigate the results much faster!
 
 All tests share the same conceptual split between the producer's model and the
 grid-side model:
@@ -71,20 +70,20 @@ This gives rise to the following conceptual hierarchy:
 
 .. code-block::
 
-launcher
-├── <PCS a>
-│   ├── <Benchmark j>
-│   │   └── <Operating Condition x>
-│   │       └── <Operating Point>
-│   └── <Benchmark k>
-│       ├── <Operating Condition y>
-│       │   └── <Operating Point>
-│       └── <Operating Condition z>
-│           └── <Operating Point>
-├── <PCS b>
-│   └── ...
-└── <PCS c>
-└── ...
+   launcher
+   ├── <PCS a>
+   │   ├── <Benchmark j>
+   │   │   └── <Operating Condition x>
+   │   │       └── <Operating Point>
+   │   └── <Benchmark k>
+   │       ├── <Operating Condition y>
+   │       │   └── <Operating Point>
+   │       └── <Operating Condition z>
+   │           └── <Operating Point>
+   ├── <PCS b>
+   │   └── ...
+   └── <PCS c>
+       └── ...
 
 That is, the launcher runs one or more DTR PCSs (the user may configure which
 ones to run or skip). Each PCS runs the tests defined in the DTR. Each test
@@ -256,10 +255,6 @@ defined by an operating point (OP), event parameters, and grid parameters.
       - :math:`U_n,\ P_{max},\ Q=0`
       - :math:`{\Delta}Q^{sp}=-5\%Q_{max}`
       - SCR=3
-    * - grid :math:`{\omega}` ramp
-      - :math:`U_n,\ P_{max},\ Q=0`
-      - :math:`{\Delta}{\omega}=+0.5Hz\ in\ 250ms`
-      - SCR=3
     * - grid V step
       - :math:`0.95U_n,\ 0.5P_{max},\ Q_{min}`
       - :math:`{\Delta}V=+10\%U_n`
@@ -320,6 +315,10 @@ defined by an operating point (OP), event parameters, and grid parameters.
       - :math:`U_n,\ P_{max},\ Q_{min}`
       - specified V profile
       - :math:`X_{min}`
+    * - grid :math:`{\omega}` ramp
+      - :math:`U_n,\ P_{max},\ Q=0`
+      - :math:`{\Delta}{\omega}=+0.5Hz\ in\ 250ms`
+      - SCR=3
     * - islanding
       - :math:`U_n,\ 0.8P_{max},\ Q=0`
       - :math:`{\Delta}\ PQ = [+0.1,\ +0.04]P_{max}`

--- a/docs/tutorials/preparing_inputs.md
+++ b/docs/tutorials/preparing_inputs.md
@@ -155,18 +155,16 @@ of a `ReferenceCurves/` directory inside a case**, not to a standalone layout.
 
 ```text
 ReferenceCurves/
-└── <Technology>/
-    └── Producer/
-        ├── CurvesFiles.ini
-        ├── PCS_RTE-I*.csv
-        └── PCS_RTE-I*.dict
+└── Producer/
+    ├── CurvesFiles.ini
+    ├── PCS_RTE-I*.csv
+    └── PCS_RTE-I*.dict
 ```
 **Example:**
 `examples/Model/Wind/WECC4B/ReferenceCurves/Producer/CurvesFiles.ini`
 
 Notes:
 
-*   `<Technology>` depends on the installation type (e.g. PPM, BESS).
 *   The validation zone (Zone 1 or Zone 3) is encoded directly in the
     **PCS identifier**.
 *   Each curve file must have an associated `.dict` file.
@@ -300,10 +298,10 @@ as reference curves, but additionally require
 ```text
 ProducerCurves/
 └── <Technology>/
-    └── Producer/
-        ├── CurvesFiles.ini
-        ├── PCS_RTE-I*.csv
-        └── PCS_RTE-I*.dict
+    ├── Producer/
+    │   ├── CurvesFiles.ini
+    │   ├── PCS_RTE-I*.csv
+    │   └── PCS_RTE-I*.dict
     ├── Zone1/
     │   └── Producer.ini
     └── Zone3/


### PR DESCRIPTION
Part of #414

Two items of this issue — the wrong trees and the failing `-c` examples in
`rms_model_validation.md` and `electrical_performance_verification.md` — are
fixed in the PR for #415, which owns those files. Merge both PRs before
closing this issue.