### PR TITLE
update the report docs to the current reports

### DIFF
--- a/docs/manual/source/usage/understanding_reports.rst
+++ b/docs/manual/source/usage/understanding_reports.rst
@@ -83,17 +83,29 @@ The summary provides a **global view of all executed tests**.
 It includes:
 
 * execution metadata:
-  
-  * timestamp,
-  * Dynawo version,
+
+  * timestamp of the run,
+  * DyCoV version and commit identifier,
+  * Dynawo version (when the producer response is simulated with Dynawo),
   * model directory,
+  * reference-curves directory (RMS model validation),
 
 * a consolidated table with:
-  
+
   * PCS identifier,
   * benchmark (test type),
   * operating condition,
-  * overall result (Compliant / Non-compliant / other status).
+  * overall result.
+
+The overall result is one of twelve statuses. *Compliant* and *Non-compliant*
+are the two outcomes of a test that was evaluated; the other ten explain why a
+test could not be evaluated: *Invalid test*, *Failed simulation*, *Undefined
+validations*, *Missing some curves*, *Missing some reference curves*,
+*Missing some producer curves*, *Fault simulation fails*, *Fault dip
+unachievable*, *Simulation time out*, and *Not applicable test*. Every status
+other than *Compliant* is shown in red, and *Not applicable test* entries
+carry a footnote ("Not executed: incompatible control mode") — such tests are
+skipped, not failed.
 
 This is the primary entry point for quickly assessing the outcome of a study.
 
@@ -122,6 +134,13 @@ For RMS model validation, results are further grouped into:
 
 * **Zone 1** (unit-level),
 * **Zone 3** (plant-level).
+
+In Zone 1, the unit's connection node appears in the report as
+**InternalNode1** (the node called *Node1* in the DTR) — the name *PDR* is
+reserved for the real connection point of the complete installation, used in
+Zone 3. The injector-terminal figures (the currents Ip and Iq and the voltage
+at the converter output) are measured at **InternalNode2** (*Node2* in the
+DTR). Both nodes are labeled in the network schema included in each report.
 
 
 Structure of a test

--- a/docs/tutorials/electrical_performance_verification.md
+++ b/docs/tutorials/electrical_performance_verification.md
@@ -220,7 +220,10 @@ dycov performance
 
 ### 8.2 Example using Dynawo
 
+From a case directory containing the model:
+
 ```bash
+cd examples/Performance/Single/WECC4B
 dycov performance -m Dynawo/
 ```
 
@@ -228,8 +231,12 @@ dycov performance -m Dynawo/
 
 ### 8.3 Example using producer curves
 
+`-c` must point at the case directory — the one containing `Producer/` and
+`Producer.ini`:
+
 ```bash
-dycov performance -c ProducerCurves/
+cd examples/Performance
+dycov performance -c ProducerCurves/PPM/
 ```
 
 ---
@@ -249,10 +256,12 @@ Each PCS and its associated tests are evaluated and reported independently.
 
 In the report:
 - each test is evaluated independently,
-- results are classified as:
-  - **Compliant**
-  - **Non-compliant**
-- compliance is determined based on PCS-defined thresholds.
+- each test that could be evaluated is classified as **Compliant** or
+  **Non-compliant**, based on the PCS-defined thresholds,
+- a test that could not be evaluated carries one of ten other statuses
+  explaining why (for example *Failed simulation* or *Simulation time out*);
+  the full list is described in
+  [Understanding DyCoV reports](understanding_reports.md).
 
 ---
 

--- a/docs/tutorials/quick_start.md
+++ b/docs/tutorials/quick_start.md
@@ -155,9 +155,10 @@ You have successfully completed your first RMS model validation.
 - A `Results/` directory is created
 - PDF reports summarize the validation results (including compliance indicators)
 - HTML plots show simulated curves against reference curves
-- Each test is classified as:
-  - **Compliant**
-  - **Non-compliant**
+- Each test that could be evaluated is classified as **Compliant** or
+  **Non-compliant**; a test that could not be evaluated carries a status
+  explaining why (e.g. *Failed simulation*, *Not applicable test* — see
+  [Understanding DyCoV reports](understanding_reports.md))
 
 At this stage, focus on:
 - whether the workflow executed correctly,
@@ -213,9 +214,10 @@ You have successfully completed your first electrical performance verification.
 - A `Results/` directory is created
 - Each PCS test scenario is evaluated
 - PDF reports summarize compliance results
-- Each test is marked as:
-  - **Compliant**
-  - **Non-compliant**
+- Each test that could be evaluated is marked as **Compliant** or
+  **Non-compliant**; a test that could not be evaluated carries a status
+  explaining why (see
+  [Understanding DyCoV reports](understanding_reports.md))
 
 At this stage, focus on:
 - understanding how PCS tests are organized,

--- a/docs/tutorials/rms_model_validation.md
+++ b/docs/tutorials/rms_model_validation.md
@@ -135,13 +135,12 @@ Typical structure:
 
 ```text
 ReferenceCurves/
-└── <Technology>/
-    └── Producer/
-        ├── CurvesFiles.ini
-        ├── PCS_RTE-I16z1*.csv
-        ├── PCS_RTE-I16z1*.dict
-        ├── PCS_RTE-I16z3*.csv
-        └── PCS_RTE-I16z3*.dict
+└── Producer/
+    ├── CurvesFiles.ini
+    ├── PCS_RTE-I16z1*.csv
+    ├── PCS_RTE-I16z1*.dict
+    ├── PCS_RTE-I16z3*.csv
+    └── PCS_RTE-I16z3*.dict
 ```
 
 Notes:
@@ -203,12 +202,12 @@ Exact structure:
 ```text
 ProducerCurves/
 └── <Technology>/
-    └── Producer/
-        ├── CurvesFiles.ini
-        ├── PCS_RTE-I16z1*.csv
-        ├── PCS_RTE-I16z1*.dict
-        ├── PCS_RTE-I16z3*.csv
-        └── PCS_RTE-I16z3*.dict
+    ├── Producer/
+    │   ├── CurvesFiles.ini
+    │   ├── PCS_RTE-I16z1*.csv
+    │   ├── PCS_RTE-I16z1*.dict
+    │   ├── PCS_RTE-I16z3*.csv
+    │   └── PCS_RTE-I16z3*.dict
     ├── Zone1/
     │   └── Producer.ini
     └── Zone3/
@@ -303,14 +302,23 @@ dycov validate
 
 ### Example using Dynawo
 
+From a case directory containing the model and its reference curves:
+
 ```bash
+cd examples/Model/Wind/WECC4B
 dycov validate ReferenceCurves/ -m Dynawo/
 ```
 
 ### Example using producer curves
 
+`-c` must point at the case directory — the one containing `Producer/` and the
+per-zone `Zone1/`/`Zone3/` folders. Since the producer-curves example carries
+no reference curves of its own, the reference here is borrowed from the WECC4B
+example:
+
 ```bash
-dycov validate ReferenceCurves/ -c ProducerCurves/
+cd examples/Model
+dycov validate Wind/WECC4B/ReferenceCurves/ -c ProducerCurves/PPM/
 ```
 
 ---
@@ -321,7 +329,8 @@ dycov validate ReferenceCurves/ -c ProducerCurves/
 > DyCoV applies a standardized signal processing pipeline (time alignment,
 > resampling, filtering, and exclusion windows) before computing validation KPIs.
 >  
-> For details, see the *2.3.4 Curve Comparison Methodology* section in the User Manual.
+> For details, see the *Comparison methodology* section above and the
+> *Understanding DyCoV reports* chapter of the User Manual.
 
 A successful RMS model validation produces the following outputs:
 - a consolidated **PDF report** summarizing compliance results,
@@ -330,10 +339,12 @@ A successful RMS model validation produces the following outputs:
 
 In the report:
 - each test is evaluated independently,
-- results are classified as:
-  - **Compliant**
-  - **Non-compliant**
-- compliance is determined based on PCS‑I16 thresholds.
+- each test that could be evaluated is classified as **Compliant** or
+  **Non-compliant**, based on the PCS‑I16 thresholds,
+- a test that could not be evaluated carries one of ten other statuses
+  explaining why (for example *Failed simulation*, *Missing some reference
+  curves*, *Simulation time out* or *Not applicable test*); the full list is
+  described in [Understanding DyCoV reports](understanding_reports.md).
 
 ---
 

--- a/docs/tutorials/understanding_reports.md
+++ b/docs/tutorials/understanding_reports.md
@@ -65,8 +65,8 @@ This structure applies consistently to:
 The report begins with general contextual information:
 
 - Type of study:
-  - *Electrical Performance Verification*, or
-  - *Model Validation*
+  - *Electrical performance verification*, or
+  - *RMS model validation*
 - Technology:
   - PPM, BESS, or SM
 - Execution date
@@ -83,14 +83,26 @@ The summary provides a **global view of all executed tests**.
 It includes:
 
 - execution metadata:
-  - timestamp,
-  - Dynawo version,
+  - timestamp of the run,
+  - DyCoV version and commit identifier,
+  - Dynawo version (when the producer response is simulated with Dynawo),
   - model directory,
+  - reference-curves directory (RMS model validation),
 - a consolidated table with:
   - PCS identifier,
   - benchmark (test type),
   - operating condition,
-  - overall result (Compliant / Non-compliant / other status).
+  - overall result.
+
+The overall result is one of twelve statuses. *Compliant* and *Non-compliant*
+are the two outcomes of a test that was evaluated; the other ten explain why a
+test could not be evaluated: *Invalid test*, *Failed simulation*, *Undefined
+validations*, *Missing some curves*, *Missing some reference curves*,
+*Missing some producer curves*, *Fault simulation fails*, *Fault dip
+unachievable*, *Simulation time out*, and *Not applicable test*. Every status
+other than *Compliant* is shown in red, and *Not applicable test* entries
+carry a footnote ("Not executed: incompatible control mode") — such tests are
+skipped, not failed.
 
 This is the primary entry point for quickly assessing the outcome of a study.
 
@@ -119,6 +131,13 @@ For RMS model validation, results are further grouped into:
 
 - **Zone 1** (unit-level),
 - **Zone 3** (plant-level).
+
+In Zone 1, the unit's connection node appears in the report as
+**InternalNode1** (the node called *Node1* in the DTR) — the name *PDR* is
+reserved for the real connection point of the complete installation, used in
+Zone 3. The injector-terminal figures (the currents Ip and Iq and the voltage
+at the converter output) are measured at **InternalNode2** (*Node2* in the
+DTR). Both nodes are labeled in the network schema included in each report.
 
 ---
 


### PR DESCRIPTION
Fixes #415
Fixes #414

Besides the report-docs updates, this PR carries two items of #414 that live
in files owned by this PR: the wrong directory trees and the failing `-c`
command examples in `rms_model_validation.md` and
`electrical_performance_verification.md`.

Merge the PR for #414 first, so that #414 is closed only once all of its
content is in master.