### PR TITLE
Preserve inherited levels for unconfigured loggers

### DIFF
--- a/src/dycov/logging/logger.py
+++ b/src/dycov/logging/logger.py
@@ -38,7 +38,6 @@ class _ContextAdapter(logging.LoggerAdapter):
 class DycovLogger(logging.getLoggerClass()):
     def __init__(self, name: str) -> None:
         super(DycovLogger, self).__init__(name)
-        self.setLevel(logging.INFO)
 
     def _add_console_handler(
         self,

--- a/tests/dycov/logging/test_logger.py
+++ b/tests/dycov/logging/test_logger.py
@@ -20,6 +20,13 @@ from dycov.logging.logger import DycovLogger
 
 
 class TestDycovLogger:
+    def test_unconfigured_logger_inherits_level(self):
+        logger = logging.getLogger("third_party_logger")
+
+        assert isinstance(logger, DycovLogger)
+        assert logger.level == logging.NOTSET
+        assert logger.getEffectiveLevel() == logging.getLogger().getEffectiveLevel()
+
     @pytest.mark.skip
     def test_logger_initializes_with_console_and_file_handlers(self):
         logger = DycovLogger("test_logger")


### PR DESCRIPTION
## Summary

Fixes #377.

Keep the standard `NOTSET` level on new `DycovLogger` instances until they are
explicitly configured. This prevents importing `dycov.logging` from forcing
unrelated loggers created later to `INFO`.

## Changes

- Remove the unconditional `INFO` assignment from `DycovLogger.__init__`.
- Add a regression test for level inheritance on loggers created through
  `logging.getLogger`.

## Testing

- `uv run --frozen pytest tests/dycov/logging/test_logger.py::TestDycovLogger::test_unconfigured_logger_inherits_level -q`
- `uv run --frozen pytest -q`
- `UV_PROJECT_ENVIRONMENT=/tmp/dycov-377-full-313 uv run --frozen pytest -q`
- `UV_PROJECT_ENVIRONMENT=/tmp/dycov-377-full-313 uv run --frozen ruff check src tests/dycov/logging/test_logger.py`
- `uv run --frozen --with build python -m build --wheel --outdir /tmp/dycov-377-final-wheel`